### PR TITLE
fix: error in tasks/main.yml and formatting in tasks/Debian.yml

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -10,7 +10,7 @@
     - python3-pip
     - python3-httplib2
 
-- name : (Ubuntu) add docker apt key
+- name: (Ubuntu) add docker apt key
   apt_key:
     url: "{{ apt_docker_key }}"
     id: "{{ apt_docker_key_id }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
 - name: Include vars suitable to our OS Family
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_os_family }}.yml"
+  include_vars: "defaults/main.yml"
 
 - name: Include tasks suitable to our OS Family
   include: "{{ ansible_os_family }}.yml"


### PR DESCRIPTION
Bug fix:
tasks/main.yml was referencing a vars file that existed before being renamed in commit:
f1d0277d4807b8dc1854272801521dedeeda7a35
updated to new location of vars file (defaults/main.yml).

Also removed a space between key: name and the semi colon in tasks/Debian.yml to keep in line with the formatting of the rest of the yml.

This was causing an error - tested during use installing 'development environment'