### PR TITLE
Fix: tasks/main.yml was pointing at a missing vars file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- name: Include tasks suitable to our OS Family
-  include: "{{ ansible_os_family }}.yml"
-
 - name: Docker pip modules
   pip:
     name: "{{ item }}"


### PR DESCRIPTION
Fix: tasks/main.yml was pointing at a missing vars file

Tested while imaging another laptop.